### PR TITLE
Añadir flag de compilacion -O3 al cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ file(GLOB SOURCES_GLUI "src/glui/*.cpp" "src/glui/*.cxx" "src/glui/*.cc")
 file(GLOB SOURCES_COMPORTAMIENTOS "src/comportamientos/*.cpp" "src/comportamientos/*.cxx" "src/comportamientos/*.cc" "Comportamientos_Jugador/*.cpp")
 include_directories("include")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -std=c++11 -O3")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 


### PR DESCRIPTION
Permite simulaciones significativamente mas rapidas y no afecta demasiado apenas a los tiempos de compilacion dado que solo se cambias usualmente dos archivos